### PR TITLE
Update basecalling image to dorado v2.0.0

### DIFF
--- a/Docker/basecalling.Dockerfile
+++ b/Docker/basecalling.Dockerfile
@@ -21,13 +21,8 @@ RUN useradd -ms /bin/bash ubuntu
 USER ubuntu
 
 WORKDIR /home/ubuntu
-RUN wget https://cdn.oxfordnanoportal.com/software/analysis/dorado-0.4.1-linux-x64.tar.gz
-RUN tar -xvf dorado-0.4.1-linux-x64.tar.gz
-
-RUN ./dorado-0.4.1-linux-x64/bin/dorado download --model dna_r10.4.1_e8.2_400bps_sup@v4.2.0
-RUN ./dorado-0.4.1-linux-x64/bin/dorado download --model dna_r10.4.1_e8.2_400bps_sup@v4.2.0_5mC@v2
-RUN ./dorado-0.4.1-linux-x64/bin/dorado download --model dna_r10.4.1_e8.2_400bps_sup@v4.2.0_6mA@v3
-
+RUN wget https://cdn.oxfordnanoportal.com/software/analysis/dorado-2.0.0-linux-x64.tar.gz
+RUN tar -xvf dorado-2.0.0-linux-x64.tar.gz
 
 COPY --chown=ubuntu:ubuntu ./run_dorado.sh ./run_dorado.sh
 RUN chmod +x /home/ubuntu/run_dorado.sh

--- a/Docker/run_dorado.sh
+++ b/Docker/run_dorado.sh
@@ -12,6 +12,10 @@ while getopts "h?agl:" OPT; do
     echo "-a: pass AWS credentials specified as environment variables to the aws command"
     echo "-g: use GPU"
     echo "-l: library name"
+    echo "Environment variables:"
+    echo "BUCKET_LOCATION: S3 path with the input pod5 files (required)"
+    echo "DORADO_MODEL: dorado model complex (default: sup)"
+    echo "DORADO_ARGS: dorado basecaller flags after the reads input (default: --recursive --modified-bases 4mC_5mC 6mA)"
     exit 0
     ;;
   a)
@@ -25,6 +29,9 @@ while getopts "h?agl:" OPT; do
     ;;
   esac
 done
+
+: "${DORADO_MODEL:=sup}"
+: "${DORADO_ARGS:=--recursive --modified-bases 4mC_5mC 6mA}"
 
 if [[ -z $BUCKET_LOCATION ]]; then
   echo "Please provide a bucket location"
@@ -49,10 +56,10 @@ aws s3 cp --recursive $BUCKET_LOCATION $library_name
  
 if [[ $use_gpu == 1 ]]; then
   echo "Using GPU"
-  /home/ubuntu/dorado-0.4.1-linux-x64/bin/dorado basecaller /home/ubuntu/dna_r10.4.1_e8.2_400bps_sup@v4.2.0 $library_name --emit-moves --modified-bases-models /home/ubuntu/dna_r10.4.1_e8.2_400bps_sup@v4.2.0_5mC@v2,/home/ubuntu/dna_r10.4.1_e8.2_400bps_sup@v4.2.0_6mA@v3 > $library_name.d3.bam
+  /home/ubuntu/dorado-2.0.0-linux-x64/bin/dorado basecaller $DORADO_MODEL $library_name $DORADO_ARGS > $library_name.d3.bam
 else
   echo "Using CPU"
-  /home/ubuntu/dorado-0.4.1-linux-x64/bin/dorado basecaller -x cpu --emit-moves /home/ubuntu/dna_r10.4.1_e8.2_400bps_sup@v4.2.0 $library_name  > $library_name.d3.bam
+  /home/ubuntu/dorado-2.0.0-linux-x64/bin/dorado basecaller -x cpu $DORADO_MODEL $library_name $DORADO_ARGS > $library_name.d3.bam
 fi
 
 aws s3 cp $library_name.d3.bam $BUCKET_LOCATION


### PR DESCRIPTION
## Summary

Updates the AWS Batch basecalling image to **dorado v2.0.0** (from 0.4.1) and aligns the basecaller invocation with our current dorado workflow.

## Changes

- **`Docker/basecalling.Dockerfile`**: bump the dorado release to `2.0.0` and remove the pre-baked, pinned `@v4.2.0` model downloads. dorado now auto-selects and downloads the appropriate `sup` models at runtime, so the image tracks the latest models instead of a static set.
- **`Docker/run_dorado.sh`**: make the basecaller command runtime-configurable via two env vars, defaulting to our standard command:
  - `DORADO_MODEL` — model complex (default `sup`)
  - `DORADO_ARGS` — flags after the reads input (default `--recursive --modified-bases 4mC_5mC 6mA`)

  A single image can now serve inputs that do and don't need modified-base calls (override `DORADO_ARGS`) without a rebuild. Also drops the now-unnecessary `--emit-moves` and documents the env vars in the entrypoint's `-h` output.

## Testing

- Image builds for `linux/amd64`; `dorado --version` reports `2.0.0` and `dorado basecaller --help` confirms the `--recursive` / `--modified-bases` flags.
- Full GPU basecalling is validated on the AWS Batch GPU infrastructure.
